### PR TITLE
Add support for custom content type and deafult code

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -282,4 +282,14 @@ class Http
      * @var int
      */
     const CODE_NETWORK_AUTHENTICATION_REQUIRED = 511;
+
+    /**
+     * @var string
+     */
+    const CONTENT_TYPE_JSON = 'application/json';
+
+    /**
+     * @var string
+     */
+    const CONTENT_TYPE_HTML = 'text/html';
 }

--- a/tests/integration/ApiTest.php
+++ b/tests/integration/ApiTest.php
@@ -20,6 +20,15 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function testDefaultContentType()
+    {
+        $this->execute('GET', '/');
+        $this->assertHeaderExists('Content-Type', 'application/json; charset=UTF-8');
+    }
+
+    /**
+     * @return void
+     */
     public function testQuery()
     {
         $this->execute('GET', '/query', ['test' => 123]);
@@ -45,6 +54,24 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->execute('GET', '/headers', [], ['X-Test: 123']);
         $this->assertCode(Http::CODE_OK);
         $this->assertResponse(['test' => '123']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDefaultCode()
+    {
+        $this->execute('GET', '/html');
+        $this->assertCode(Http::CODE_OK);
+    }
+
+    /**
+     * @return void
+     */
+    public function testHtmlContentType()
+    {
+        $this->execute('GET', '/html');
+        $this->assertHeaderExists("Content-Type", "text/html; charset=UTF-8");
     }
 
     /**
@@ -98,5 +125,17 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     protected function assertResponse($data)
     {
         $this->assertSame($data, json_decode($this->response(), true));
+    }
+
+    /**
+     * Assert a response header was defined
+     *
+     * @param  string $header
+     * @return void
+     */
+    protected function assertHeaderExists($name, $value)
+    {
+        $this->assertArrayHasKey($name, $this->headers());
+        $this->assertSame($value, $this->headers()[$name]);
     }
 }

--- a/tests/integration/fixture/endpoints/html.php
+++ b/tests/integration/fixture/endpoints/html.php
@@ -1,0 +1,10 @@
+<?php
+
+use \trifs\DIServer\Http;
+
+return function ($app) {
+    return [
+        'data'        => 'test',
+        'contentType' => Http::CONTENT_TYPE_HTML,
+    ];
+};

--- a/tests/integration/fixture/routes.php
+++ b/tests/integration/fixture/routes.php
@@ -9,5 +9,6 @@ return function () {
         ['GET', '/query', 'parameter'],
         ['POST', '/postData', 'parameter'],
         ['GET', '/headers', 'headers'],
+        ['GET', '/html', 'html'],
     ];
 };

--- a/tests/unit/DIServer/ResponseTest.php
+++ b/tests/unit/DIServer/ResponseTest.php
@@ -6,7 +6,6 @@ use \trifs\DIServer\Response;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @return void
      */
@@ -31,6 +30,18 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function testSuccessShouldWorkWithoutTheCode()
+    {
+        $this->expectOutputString('["data"]');
+        $response = new Response;
+        $response->success([
+            'data' => ['data'],
+        ]);
+    }
+
+    /**
+     * @return void
+     */
     public function testSuccessShouldOutputEmptyStringWhenDataIsSetToNull()
     {
         $this->expectOutputString('""');
@@ -48,8 +59,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = $this->getMock('\trifs\DIServer\Response', ['setHeaders']);
         $response->expects($this->once())
-                 ->method('setHeaders')
-                 ->with(404);
+            ->method('setHeaders')
+            ->with(['code' => 404]);
 
         $this->expectOutputString('{"error":"message"}');
 
@@ -63,8 +74,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = $this->getMock('\trifs\DIServer\Response', ['setHeaders']);
         $response->expects($this->once())
-                 ->method('setHeaders')
-                 ->with(Http::CODE_INTERNAL_ERROR);
+            ->method('setHeaders')
+            ->with(['code' => Http::CODE_INTERNAL_ERROR]);
 
         $this->expectOutputString('{"error":"message"}');
 

--- a/tests/unit/DIServer/TestCase.php
+++ b/tests/unit/DIServer/TestCase.php
@@ -17,7 +17,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->app = new Container;
-
         parent::setUp();
     }
 }


### PR DESCRIPTION
Response content type can now be set to either application/json or text/html.
Default code (`200 OK`) will be returned if not defined.
